### PR TITLE
B-2: python linters fix

### DIFF
--- a/.github/workflows/python_linters.yaml
+++ b/.github/workflows/python_linters.yaml
@@ -1,4 +1,4 @@
-name: Python linters
+name: python linters
 
 
 on:
@@ -6,6 +6,9 @@ on:
     workflows: [build]
     types:
       - completed
+      
+env:
+  PYTHON_VERSION: '3.11'
 
 
 jobs:


### PR DESCRIPTION
A possible fix for python linters not being able to load cached python libraries.